### PR TITLE
Fix dropdown unreadable

### DIFF
--- a/themes/sweetpink.yaml
+++ b/themes/sweetpink.yaml
@@ -173,6 +173,7 @@ sweetpink:
   mdc-select-idle-line-color: "var(--primary-color)"
   mdc-select-dropdown-icon-color: "var(--secondary-text-color)"
   mdc-select-hover-line-color: "var(--accent-color)"
+  input-fill-color: "var(--purple)"
 
   # Vaadin elements
   vaadin-text-field-input-line: "var(--primary-color)"


### PR DESCRIPTION
Added line for input-fill-colour to fix issue where automation dropdown has a white background and white text