### PR TITLE
Adding in main page header variables

### DIFF
--- a/themes/sweetpink.yaml
+++ b/themes/sweetpink.yaml
@@ -183,3 +183,7 @@ sweetpink:
 
   # Markdown
   markdown-code-background-color: "var(--secondary-background-color)"
+
+  # Main page header
+  app-header-background-color: "var(--pink)"
+  app-header-text-color: "var(--white)"


### PR DESCRIPTION
HA 2026.2 set the header colour to the same colour as the main background. Added in variables to set the header colour back to pink.